### PR TITLE
Add trends to choice the prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 const readline = require('readline-sync')
+const googleTrends = require('google-trends-api');
+const math = require('mathjs')
 const robots = {
   text: require('./robots/text.js')
 }
@@ -7,7 +9,9 @@ async function start() {
   const content = {}
 
   content.searchTerm = askAndReturnSearchTerm()
-  content.prefix = askAndReturnPrefix()
+  content.prefix = await getPrexifTrends(content.searchTerm)
+
+  console.log(content)
 
   await robots.text(content)
 
@@ -15,12 +19,31 @@ async function start() {
     return readline.question('Type a Wikipedia search term: ')
   }
 
-  function askAndReturnPrefix() {
+  async function getPrexifTrends(searchTerm) {
     const prefixes = ['Who is', 'What is', 'The history of']
-    const selectedPrefixIndex = readline.keyInSelect(prefixes, 'Choose one option: ')
-    const selectedPrefixText = prefixes[selectedPrefixIndex]
+    let prefixesTrend = []
+    let mostTrend;
+    prefixes.forEach((elem) => {
+      prefixesTrend.push(elem + ' ' + searchTerm);
+    });
 
-    return selectedPrefixText
+    return googleTrends.interestOverTime({ keyword: prefixesTrend }).then((results) => {
+      let data = JSON.parse(results);
+      let values = [];
+      data.default.timelineData.forEach((elem) => {
+        values.push(elem.value);
+      });
+
+      let mostTrends = [];
+      math.transpose(values).forEach((elem) => {
+        mostTrends.push(math.sum(elem));
+      });
+
+      return prefixes[mostTrends.indexOf(math.max(mostTrends))];
+    }).catch((err) => {
+      console.error('Oh no there was an error', err);
+      return prefixes[Math.random() * prefixes.length];
+    });
   }
 
   console.log(content)

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   "dependencies": {
     "algorithmia": "^0.3.10",
     "readline-sync": "^1.4.9",
-    "sbd": "^1.0.14"
+    "sbd": "^1.0.14",
+    "google-trends-api": "4.9.0",
+    "mathjs": "5.6.0",
   }
 }


### PR DESCRIPTION

![prefixes](https://user-images.githubusercontent.com/17098382/53908568-65141900-402e-11e9-8c31-4de166921fd8.gif)





Olá pessoal, aproveitando essa onda de programação inteligente e a maaaravilhosa ideia de utilizar o Google Trends do @wellingtonsilverio  e @danielschmitz, resolvi incrementar com uma ideia a mais:

- Criei uma função `getPrexifTrends(searchTerm)` para que utilizando o Google Trends, por meio da API `google-trends-api`, ele possa verificar qual o mais recorrente prefixo utilizado. Desse modo o usuário preocupa-se apenas com o título do vídeo gerado.
- Utilizei a API `mathjs` para torna a operação com matrizes mais facilitada pois eu deveria somar os pontos de cada prefixo buscado.
- Também precisei colocar um `console.log(content)` bem no meio do código pois nessa versão devo ter pegue o bonde andando e o `await robots.text(content)` andou me bugando.
