### PR TITLE
Refatoração: remover redundância de condicional

### DIFF
--- a/robots/text.js
+++ b/robots/text.js
@@ -25,13 +25,9 @@ async function robot(content) {
     function removeBlankLinesAndMarkdown(text) {
       const allLines = text.split('\n')
 
-      const withoutBlankLinesAndMarkdown = allLines.filter((line) => {
-        if (line.trim().length === 0 || line.trim().startsWith('=')) {
-          return false
-        }
-
-        return true
-      })
+      const withoutBlankLinesAndMarkdown = allLines.filter(
+        (line) => !(line.trim().length === 0 || line.trim().startsWith('='))
+      )
 
       return withoutBlankLinesAndMarkdown.join(' ')
     }

--- a/robots/text.js
+++ b/robots/text.js
@@ -26,7 +26,7 @@ async function robot(content) {
       const allLines = text.split('\n')
 
       const withoutBlankLinesAndMarkdown = allLines.filter(
-        (line) => !(line.trim().length === 0 || line.trim().startsWith('='))
+        (line) => line.trim() && !line.trim().startsWith('=')
       )
 
       return withoutBlankLinesAndMarkdown.join(' ')


### PR DESCRIPTION
A PR remove um `if`/`else` desnecessário. Basta retornar um valor booleano diretamente, usando a notação cura das _arrow functions_. :)