### PR TITLE
Removendo API do algoritmia e adicionando títulos relacionados ao searchTerm 

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,13 +8,23 @@ async function start() {
     maximumSentences: 7
   }
 
-  content.searchTerm = askAndReturnSearchTerm()
+  content.searchTerm = await askAndReturnSearchTerm()
   content.prefix = askAndReturnPrefix()
 
+  await robots.text(content)
+  await askAndReturnPossibleTitles()
   await robots.text(content)
 
   function askAndReturnSearchTerm() {
     return readline.question('Type a Wikipedia search term: ')
+  }
+
+  async function askAndReturnPossibleTitles() {
+    const titlesPrefixes = content.titlePrefixes
+    const selectedTitlePrefixIndex = readline.keyInSelect(titlesPrefixes, 'Choose one title:')
+    const selectedTitlePrefixText = titlesPrefixes[selectedTitlePrefixIndex]
+
+    content.selectedTerm = selectedTitlePrefixText
   }
 
   function askAndReturnPrefix() {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/filipedeschamps/video-maker#readme",
   "dependencies": {
-    "algorithmia": "^0.3.10",
+    "node-fetch": "^2.3.0",
     "readline-sync": "^1.4.9",
     "sbd": "^1.0.14",
     "watson-developer-cloud": "^3.18.2"


### PR DESCRIPTION
Olá, 

Tem sido muito bacana ter a oportunidade de fazer parte desse projeto incrível, fico feliz em poder ajudar.

Bom, como a API do Algoritmia tem um número limitado de requisições, decidi remove-la e implementar um algoritmo que faça esse parse sem a necessidade de utilizar uma API com limitações desse tipo.

Aproveitando esse caminho aproveitei também para implementar a busca por resultados relacionados ao searchTerm, trazendo assim uma maior possibilidade de escolha ao usuário.