### PR TITLE
Simplificações de código e paralelização de fetchs de keywords do Watson.

### DIFF
--- a/robots/input.js
+++ b/robots/input.js
@@ -3,25 +3,23 @@ const state = require('./state.js')
 
 function robot() {
   const content = {
-    maximumSentences: 7
+    maximumSentences: 7,
+    searchTerm: askAndReturnSearchTerm(),
+    prefix: askAndReturnPrefix()
   }
-
-  content.searchTerm = askAndReturnSearchTerm()
-  content.prefix = askAndReturnPrefix()
   state.save(content)
+}
 
-  function askAndReturnSearchTerm() {
-    return readline.question('Type a Wikipedia search term: ')
-  }
+function askAndReturnSearchTerm() {
+  return readline.question('Type a Wikipedia search term: ')
+}
 
-  function askAndReturnPrefix() {
-    const prefixes = ['Who is', 'What is', 'The history of']
-    const selectedPrefixIndex = readline.keyInSelect(prefixes, 'Choose one option: ')
-    const selectedPrefixText = prefixes[selectedPrefixIndex]
+function askAndReturnPrefix() {
+  const prefixes = ['Who is', 'What is', 'The history of']
+  const selectedPrefixIndex = readline.keyInSelect(prefixes, 'Choose one option: ')
+  const selectedPrefixText = prefixes[selectedPrefixIndex]
 
-    return selectedPrefixText
-  }
-
+  return selectedPrefixText
 }
 
 module.exports = robot

--- a/robots/text.js
+++ b/robots/text.js
@@ -51,7 +51,7 @@ function sanitizeContent(content) {
 }
 
 function removeDatesInParentheses(text) {
-  return text.replace(/\((?:\([^()]*\)|[^()])*\)/gm, '').replace(/\s+/g,' ')
+  return text.replace(/\((?:\([^()]*\)|[^()])*\)/gm, '').replace(/\s{2,}/g,' ')
 }
 
 function breakContentIntoSentences(content) {

--- a/robots/text.js
+++ b/robots/text.js
@@ -88,12 +88,10 @@ async function fetchWatsonAndReturnKeywords(sentence) {
       }
     }, (error, response) => {
       if (error) {
-        reject(error)
+        return reject(error)
       }
 
-      const keywords = response.keywords.map((keyword) => {
-        return keyword.text
-      })
+      const keywords = response.keywords.map(keyword => keyword.text)
 
       resolve(keywords)
     })

--- a/robots/text.js
+++ b/robots/text.js
@@ -72,9 +72,11 @@ function limitMaximumSentences(content) {
 }
 
 async function fetchKeywordsOfAllSentences(content) {
-  for (const sentence of content.sentences) {
-    sentence.keywords = await fetchWatsonAndReturnKeywords(sentence.text)
-  }
+  await Promise.all(
+    content.sentences.map(
+      async sentence => sentence.keywords = await fetchWatsonAndReturnKeywords(sentence.text)
+    )
+  )
 }
 
 async function fetchWatsonAndReturnKeywords(sentence) {

--- a/robots/text.js
+++ b/robots/text.js
@@ -51,7 +51,7 @@ function sanitizeContent(content) {
 }
 
 function removeDatesInParentheses(text) {
-  return text.replace(/\((?:\([^()]*\)|[^()])*\)/gm, '').replace(/  /g,' ')
+  return text.replace(/\((?:\([^()]*\)|[^()])*\)/gm, '').replace(/\s+/g,' ')
 }
 
 function breakContentIntoSentences(content) {

--- a/robots/text.js
+++ b/robots/text.js
@@ -22,85 +22,84 @@ async function robot() {
   await fetchKeywordsOfAllSentences(content)
 
   state.save(content)
+}
 
-  async function fetchContentFromWikipedia(content) {
-    const algorithmiaAuthenticated = algorithmia(algorithmiaApiKey)
-    const wikipediaAlgorithm = algorithmiaAuthenticated.algo('web/WikipediaParser/0.1.2')
-    const wikipediaResponse = await wikipediaAlgorithm.pipe(content.searchTerm)
-    const wikipediaContent = wikipediaResponse.get()
+async function fetchContentFromWikipedia(content) {
+  const algorithmiaAuthenticated = algorithmia(algorithmiaApiKey)
+  const wikipediaAlgorithm = algorithmiaAuthenticated.algo('web/WikipediaParser/0.1.2')
+  const wikipediaResponse = await wikipediaAlgorithm.pipe(content.searchTerm)
+  const wikipediaContent = wikipediaResponse.get()
 
-    content.sourceContentOriginal = wikipediaContent.content
-  }
+  content.sourceContentOriginal = wikipediaContent.content
+}
 
-  function sanitizeContent(content) {
-    const withoutBlankLinesAndMarkdown = removeBlankLinesAndMarkdown(content.sourceContentOriginal)
-    const withoutDatesInParentheses = removeDatesInParentheses(withoutBlankLinesAndMarkdown)
+function sanitizeContent(content) {
+  const withoutBlankLinesAndMarkdown = removeBlankLinesAndMarkdown(content.sourceContentOriginal)
+  const withoutDatesInParentheses = removeDatesInParentheses(withoutBlankLinesAndMarkdown)
 
-    content.sourceContentSanitized = withoutDatesInParentheses
+  content.sourceContentSanitized = withoutDatesInParentheses
 
-    function removeBlankLinesAndMarkdown(text) {
-      const allLines = text.split('\n')
+  function removeBlankLinesAndMarkdown(text) {
+    const allLines = text.split('\n')
 
-      const withoutBlankLinesAndMarkdown = allLines.filter((line) => {
-        if (line.trim().length === 0 || line.trim().startsWith('=')) {
-          return false
-        }
+    const withoutBlankLinesAndMarkdown = allLines.filter((line) => {
+      if (line.trim().length === 0 || line.trim().startsWith('=')) {
+        return false
+      }
 
-        return true
-      })
-
-      return withoutBlankLinesAndMarkdown.join(' ')
-    }
-  }
-
-  function removeDatesInParentheses(text) {
-    return text.replace(/\((?:\([^()]*\)|[^()])*\)/gm, '').replace(/  /g,' ')
-  }
-
-  function breakContentIntoSentences(content) {
-    content.sentences = []
-
-    const sentences = sentenceBoundaryDetection.sentences(content.sourceContentSanitized)
-    sentences.forEach((sentence) => {
-      content.sentences.push({
-        text: sentence,
-        keywords: [],
-        images: []
-      })
+      return true
     })
+    
+    return withoutBlankLinesAndMarkdown.join(' ')
   }
+}
 
-  function limitMaximumSentences(content) {
-    content.sentences = content.sentences.slice(0, content.maximumSentences)
-  }
+function removeDatesInParentheses(text) {
+  return text.replace(/\((?:\([^()]*\)|[^()])*\)/gm, '').replace(/  /g,' ')
+}
 
-  async function fetchKeywordsOfAllSentences(content) {
-    for (const sentence of content.sentences) {
-      sentence.keywords = await fetchWatsonAndReturnKeywords(sentence.text)
-    }
-  }
+function breakContentIntoSentences(content) {
+  content.sentences = []
 
-  async function fetchWatsonAndReturnKeywords(sentence) {
-    return new Promise((resolve, reject) => {
-      nlu.analyze({
-        text: sentence,
-        features: {
-          keywords: {}
-        }
-      }, (error, response) => {
-        if (error) {
-          throw error
-        }
-
-        const keywords = response.keywords.map((keyword) => {
-          return keyword.text
-        })
-
-        resolve(keywords)
-      })
+  const sentences = sentenceBoundaryDetection.sentences(content.sourceContentSanitized)
+  sentences.forEach((sentence) => {
+    content.sentences.push({
+      text: sentence,
+      keywords: [],
+      images: []
     })
-  }
+  })
+}
 
+function limitMaximumSentences(content) {
+  content.sentences = content.sentences.slice(0, content.maximumSentences)
+}
+
+async function fetchKeywordsOfAllSentences(content) {
+  for (const sentence of content.sentences) {
+    sentence.keywords = await fetchWatsonAndReturnKeywords(sentence.text)
+  }
+}
+
+async function fetchWatsonAndReturnKeywords(sentence) {
+  return new Promise((resolve, reject) => {
+    nlu.analyze({
+      text: sentence,
+      features: {
+        keywords: {}
+      }
+    }, (error, response) => {
+      if (error) {
+        throw error
+      }
+
+      const keywords = response.keywords.map((keyword) => {
+        return keyword.text
+      })
+
+      resolve(keywords)
+    })
+  })
 }
 
 module.exports = robot

--- a/robots/text.js
+++ b/robots/text.js
@@ -4,14 +4,13 @@ const sentenceBoundaryDetection = require('sbd')
 
 const watsonApiKey = require('../credentials/watson-nlu.json').apikey
 const NaturalLanguageUnderstandingV1 = require('watson-developer-cloud/natural-language-understanding/v1.js')
- 
+const state = require('./state.js')
+
 const nlu = new NaturalLanguageUnderstandingV1({
   iam_apikey: watsonApiKey,
   version: '2018-04-05',
   url: 'https://gateway.watsonplatform.net/natural-language-understanding/api/'
 })
-
-const state = require('./state.js')
 
 async function robot() {
   const content = state.load()

--- a/robots/text.js
+++ b/robots/text.js
@@ -88,7 +88,7 @@ async function fetchWatsonAndReturnKeywords(sentence) {
       }
     }, (error, response) => {
       if (error) {
-        throw error
+        reject(error)
       }
 
       const keywords = response.keywords.map((keyword) => {

--- a/robots/text.js
+++ b/robots/text.js
@@ -42,14 +42,10 @@ function sanitizeContent(content) {
   function removeBlankLinesAndMarkdown(text) {
     const allLines = text.split('\n')
 
-    const withoutBlankLinesAndMarkdown = allLines.filter((line) => {
-      if (line.trim().length === 0 || line.trim().startsWith('=')) {
-        return false
-      }
+    const withoutBlankLinesAndMarkdown = allLines.filter(
+      line => line.trim() && !line.trim().startsWith('=') 
+    )
 
-      return true
-    })
-    
     return withoutBlankLinesAndMarkdown.join(' ')
   }
 }


### PR DESCRIPTION
- Simplifica código e evita que funções sejam recriada a cada chamada de robot()
- Agrupa import de state.js com outros imports
- Move funções para fora de closure, evitando recriação por escopo
- Simplifica avaliação de withoutBlankLinesAndMarkdown
- Melhora regex para substituição de espaços contíguos
- Paraleliza o fetch de keywords do Watson
- Utiliza reject em new Promise ao inves de "throw error"
- Simplifica mapping de keywords