### PR TITLE
Ajuste de performance na recuperação das keywords

### DIFF
--- a/robots/text.js
+++ b/robots/text.js
@@ -76,15 +76,21 @@ async function robot() {
   }
 
   async function fetchKeywordsOfAllSentences(content) {
+    const listOfKeywordsToFetch = []
+
     for (const sentence of content.sentences) {
-      sentence.keywords = await fetchWatsonAndReturnKeywords(sentence.text)
+      listOfKeywordsToFetch.push(
+        fetchWatsonAndReturnKeywords(sentence)
+      )
     }
+
+    await Promise.all(listOfKeywordsToFetch)
   }
 
   async function fetchWatsonAndReturnKeywords(sentence) {
     return new Promise((resolve, reject) => {
       nlu.analyze({
-        text: sentence,
+        text: sentence.text,
         features: {
           keywords: {}
         }
@@ -96,6 +102,8 @@ async function robot() {
         const keywords = response.keywords.map((keyword) => {
           return keyword.text
         })
+
+        sentence.keywords = keywords
 
         resolve(keywords)
       })


### PR DESCRIPTION
Fiz um pequeno ajuste na função `fetchWatsonAndReturnKeywords` que é responsável por recuperar as keywords para cada sentença do texto que veio do Wikipedia.

A biblioteca responsável pela comunicação com o Watson envia uma chamada HTTP para cada vez que o método `analyze` for chamado. Uma vez que as keywords estão sendo recuperadas dentro de um `for`, o processamento síncrono do `async/await` faz com que as chamadas HTTP sejam enviadas de forma enfileirada, havendo o próximo envio apenas quando o envio anterior tiver sido concluído, o que pode acabar prejudicando a performance do robô de texto.

As chamadas HTTP para o Watson podem ser enviadas simultaneamente usando o `Promise.all`, que recebe uma lista de promises e as processa de forma simultânea, fazendo o `resolve` e enviando o retorno assim que a chamada mais "atrasada" for concluída.