### PR TITLE
Duplicate property

### DIFF
--- a/robots/image.js
+++ b/robots/image.js
@@ -65,7 +65,7 @@ async function robot() {
 
   async function downloadAndSave(url, fileName) {
     return imageDownloader.image({
-      url, url,
+      url,
       dest: `./content/${fileName}`
     })
   }


### PR DESCRIPTION
Listing the same property twice in one object literal is redundant and may indicate a copy-paste mistake.