### PR TITLE
README.md - Erro de virgula google-search.json / Erro português vai "…

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Você precisa criar também as credenciais do *Watson* no site da [IBM](https://
 
 ![IBM](https://i.imgsafe.org/ba/bab0fc4ecd.jpeg)
 
-clicando nele na nova página vai aparece um botão "criar" no final da página, uma vez que o serviço for criado, você será redirecionado para a página de gerenciamento do serviço que você acabou de criar, no menu lateral esquerdo procure por **Credenciais de Serviços** e depois clique em **Auto-generated service credentials** destacado abaixo, então copie as *Credenciais*:
+clicando nele na nova página vai aparecer um botão "criar" no final da página, uma vez que o serviço for criado, você será redirecionado para a página de gerenciamento do serviço que você acabou de criar, no menu lateral esquerdo procure por **Credenciais de Serviços** e depois clique em **Auto-generated service credentials** destacado abaixo, então copie as *Credenciais*:
 
 ![IBM](https://i.imgsafe.org/ba/bace46f16b.jpeg)
 
@@ -133,7 +133,7 @@ Voltando no arquivo **google-search.json** iremos criar uma nova propriedade e i
 
 ```
 {
-  "apiKey": "API_KEY_AQUI"
+  "apiKey": "API_KEY_AQUI",
   "searchEngineId": "ID_MECANISMO_DE_BUSCA"
 }
 ```


### PR DESCRIPTION
…aparece"

Faltou uma virgula no código google-search.json
Estava acusando o seguinte erro:

video-maker\credentials\google-search.json: Unexpected string in JSON at position 64
    at JSON.parse (<anonymous>)
    at Object.Module._extensions..json (internal/modules/cjs/loader.js:795:27)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Module.require (internal/modules/cjs/loader.js:690:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at Object.<anonymous> (E:\robovideoyoutube\video-maker\robots\image.js:6:33)
    at Module._compile (internal/modules/cjs/loader.js:776:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:787:10)


Corrigido erro de português:
clicando nele na nova página vai aparece*r* um botão "criar"