### PR TITLE
Fix some errors from text robot

### DIFF
--- a/robots/text.js
+++ b/robots/text.js
@@ -103,7 +103,7 @@ async function robot() {
           return
         }
 
-        const keywords = response.result.keywords.map((keyword) => {
+        const keywords = response.keywords.map((keyword) => {
           return keyword.text
         })
 

--- a/robots/text.js
+++ b/robots/text.js
@@ -66,11 +66,13 @@ async function robot() {
 
     const sentences = sentenceBoundaryDetection.sentences(content.sourceContentSanitized)
     sentences.forEach((sentence) => {
+     if (sentence.length > 32){
       content.sentences.push({
         text: sentence,
         keywords: [],
         images: []
       })
+     }
     })
   }
 


### PR DESCRIPTION
Errors fixed:
- Trying to define `keywords` from `response.result` instead of `response`
- Th keywords api is unable to process short sentences