### PR TITLE
removing unnecessary require of state

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 const robots = {
   input: require('./robots/input.js'),
   text: require('./robots/text.js'),
-  state: require('./robots/state.js'),
   image: require('./robots/image.js'),
   video: require('./robots/video.js'),
   youtube: require('./robots/youtube.js')


### PR DESCRIPTION
Apenas removendo a importação desnecessária do robô de estado dentro do orquestrador (index.js), uma vez que este era usado unicamente para logar o resultado das buscas, para efeito de testes durante o desenvolvimento.