### PR TITLE
O retorno da API do Watson foi atualizado

### DIFF
--- a/robots/text.js
+++ b/robots/text.js
@@ -103,7 +103,7 @@ async function robot() {
           return
         }
 
-        const keywords = response.result.keywords.map((keyword) => {
+        const keywords = response.keywords.map((keyword) => {
           return keyword.text
         })
 


### PR DESCRIPTION
A API do Watson não retorna mais response.result.keywords. Ao invés disso, está retornando response.keywords